### PR TITLE
security: remove polyfill.io script tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,6 @@
       type="text/css"
       media="all"
     />
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=String.prototype.replaceAll%2CIntersectionObserver%2CArray.prototype.map%2CArray.prototype.reduce"></script>
     <script
       type="text/javascript"
       src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDy8e6_8uv8JnNZFRXng6HfbhnhvobWyac&libraries=places"


### PR DESCRIPTION
## Summary

- Removes the `polyfill.io` CDN script tag from `public/index.html`

The polyfill.io domain was sold in 2024 to an external company that started injecting malicious JavaScript into CDN responses, targeting mobile users with redirects to scam sites. The original library author publicly recommended against using it, and AGID published an official advisory.

All loaded features (`String.prototype.replaceAll`, `IntersectionObserver`, `Array.prototype.map`, `Array.prototype.reduce`) are natively supported by all browsers released in the last 5 years — no alternative polyfill is needed.

**Reference:** https://www.agid.gov.it/it/notizie/polyfillio-il-cert-agid-consiglia-alle-pa-che-lo-utilizzano-sui-loro-siti-di-rimuoverlo

## Test plan

- [x] Verify the app loads correctly in Chrome, Firefox, Safari
- [x] Verify no console errors related to missing polyfills
- [x] Check that features using `replaceAll`, `IntersectionObserver`, `map`, `reduce` still work as expected